### PR TITLE
pt:installed-apps - fix module not found error

### DIFF
--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -73,7 +73,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'authentication',
-    'django_bootstrap5'
+    'django_bootstrap5',
     'landingPage',
 ]
 


### PR DESCRIPTION
# [Patch] Fix module not found error

## Description

Fixes the module not found error by separating installed apps.
